### PR TITLE
Fix foreign member

### DIFF
--- a/src/topojson/topojson.ml
+++ b/src/topojson/topojson.ml
@@ -54,6 +54,7 @@ module Make (J : Intf.Json) = struct
       | Ok assoc ->
           List.filter (fun (k, _v) -> not (List.mem k keys_in_use)) assoc
       | Error _ -> []
+
     let parse_with_coords json p_c typ =
       match (J.find json [ "type" ], J.find json [ "coordinates" ]) with
       | None, _ ->
@@ -124,7 +125,6 @@ module Make (J : Intf.Json) = struct
       let position = Fun.id
       let v position = position
       let parse_coords coords = J.to_array (decode_or_err J.to_float) coords
-
       let base_of_json json = parse_with_coords json parse_coords typ
 
       let to_json ?bbox ?(properties = `None) ?(foreign_members = []) position =
@@ -326,8 +326,8 @@ module Make (J : Intf.Json) = struct
                     geometry = Polygon g;
                     properties;
                     foreign_members = fm keys_in_use;
-                    id
-                   })
+                    id;
+                  })
               @@ Polygon.base_of_json json
           | Ok "MultiPolygon" ->
               Result.map (fun g ->

--- a/src/topojson/topojson.ml
+++ b/src/topojson/topojson.ml
@@ -321,7 +321,12 @@ module Make (J : Intf.Json) = struct
               @@ MultiLineString.base_of_json json
           | Ok "Polygon" ->
               Result.map (fun g ->
-                  { geometry = Polygon g; properties; foreign_members = fm keys_in_use; id })
+                  {
+                    geometry = Polygon g;
+                    properties;
+                    foreign_members = fm keys_in_use;
+                    id
+                   })
               @@ Polygon.base_of_json json
           | Ok "MultiPolygon" ->
               Result.map (fun g ->

--- a/src/topojson/topojson.ml
+++ b/src/topojson/topojson.ml
@@ -49,20 +49,11 @@ module Make (J : Intf.Json) = struct
         "geometries";
       ]
 
-    let foreign_members_of_json json =
+    let foreign_members_of_json json keys_in_use =
       match J.to_obj json with
       | Ok assoc ->
           List.filter (fun (k, _v) -> not (List.mem k keys_in_use)) assoc
       | Error _ -> []
-
-    let foreign_members_of_json_for_point json =
-      match J.to_obj json with
-      | Ok assoc ->
-          List.filter
-            (fun (k, _v) -> not (List.mem k keys_in_use_for_point))
-            assoc
-      | Error _ -> []
-
     let parse_with_coords json p_c typ =
       match (J.find json [ "type" ], J.find json [ "coordinates" ]) with
       | None, _ ->
@@ -294,25 +285,19 @@ module Make (J : Intf.Json) = struct
           match J.to_string typ with
           | Ok "Point" ->
               Result.map (fun g ->
-                  let point_foreign_members =
-                    foreign_members_of_json_for_point json
-                  in
                   {
                     geometry = Point g;
                     properties;
-                    foreign_members = point_foreign_members;
+                    foreign_members = fm keys_in_use_for_point;
                     id;
                   })
               @@ Point.base_of_json json
           | Ok "MultiPoint" ->
               Result.map (fun g ->
-                  let point_foreign_members =
-                    foreign_members_of_json_for_point json
-                  in
                   {
                     geometry = MultiPoint g;
                     properties;
-                    foreign_members = point_foreign_members;
+                    foreign_members = fm keys_in_use_for_point;
                     id;
                   })
               @@ MultiPoint.base_of_json json
@@ -321,7 +306,7 @@ module Make (J : Intf.Json) = struct
                   {
                     geometry = LineString g;
                     properties;
-                    foreign_members = fm;
+                    foreign_members = fm keys_in_use;
                     id;
                   })
               @@ LineString.base_of_json json
@@ -330,20 +315,20 @@ module Make (J : Intf.Json) = struct
                   {
                     geometry = MultiLineString g;
                     properties;
-                    foreign_members = fm;
+                    foreign_members = fm keys_in_use;
                     id;
                   })
               @@ MultiLineString.base_of_json json
           | Ok "Polygon" ->
               Result.map (fun g ->
-                  { geometry = Polygon g; properties; foreign_members = fm; id })
+                  { geometry = Polygon g; properties; foreign_members = fm keys_in_use; id })
               @@ Polygon.base_of_json json
           | Ok "MultiPolygon" ->
               Result.map (fun g ->
                   {
                     geometry = MultiPolygon g;
                     properties;
-                    foreign_members = fm;
+                    foreign_members = fm keys_in_use;
                     id;
                   })
               @@ MultiPolygon.base_of_json json
@@ -356,7 +341,7 @@ module Make (J : Intf.Json) = struct
                       {
                         geometry = Collection g;
                         properties;
-                        foreign_members = fm;
+                        foreign_members = fm keys_in_use;
                         id;
                       })
                     geo

--- a/src/topojson/topojson.ml
+++ b/src/topojson/topojson.ml
@@ -124,6 +124,7 @@ module Make (J : Intf.Json) = struct
       let position = Fun.id
       let v position = position
       let parse_coords coords = J.to_array (decode_or_err J.to_float) coords
+
       let base_of_json json = parse_with_coords json parse_coords typ
 
       let to_json ?bbox ?(properties = `None) ?(foreign_members = []) position =

--- a/src/topojson/topojson_intf.ml
+++ b/src/topojson/topojson_intf.ml
@@ -97,7 +97,7 @@ module type Geometry = sig
     (** Convert a point to a position *)
 
     val v : Position.t -> t
-    (** Create a poitn from a position. *)
+    (** Create a point from a position. *)
   end
 
   module MultiPoint : sig

--- a/test/topojson/test.ml
+++ b/test/topojson/test.ml
@@ -61,6 +61,12 @@ let pp_position ppf t =
   let lng = Position.lng t in
   Fmt.pf ppf "[%f, %f]" lat lng
 
+let foreign_member ppf v =
+  let open Topojson.Geometry.Point in
+  let foreign = "arcs" in
+  Fmt.pf ppf "[%s]" foreign
+
+let foreign_members = Alcotest.testable foreign_member Stdlib.( = )
 let position = Alcotest.testable pp_position Stdlib.( = )
 let msg = Alcotest.testable (fun ppf (`Msg m) -> Fmt.pf ppf "%s" m) Stdlib.( = )
 
@@ -92,6 +98,8 @@ and remove acc k = function
   | (k', _) :: rest when k = k' -> List.rev acc @ rest
   | x :: rest -> remove (x :: acc) k rest
 
+let expected_foreign_members = "arcs"
+
 let ezjsonm =
   Alcotest.testable
     (fun ppf t -> Fmt.pf ppf "%s" (Ezjsonm.value_to_string t))
@@ -106,6 +114,8 @@ let main () =
       (* Here we check that the arcs defined in the file are the same as the ones
          we hardcoded above *)
       Alcotest.(check (array (array position))) "same arcs" f.arcs expected_arcs;
+      Alcotest.(check (list (list foreign_members)))
+        "same foreign_member" f.foreign_members expected_foreign_members;
       (* Then we check that converting the Topojson OCaml value to JSON and then back
          again produces the same Topojson OCaml value. *)
       let output_json = Topojson.to_json t in
@@ -117,4 +127,8 @@ let main () =
   | Error (`Msg m), _ -> failwith m
   | _, Error (`Msg m) -> failwith m
 
+(* let point = Topojson.Geometry.Point.position *)
 let () = Alcotest.run "topojson" [ ("parsing", [ ("simple", `Quick, main) ]) ]
+(* let keys_in_use_for_point = [ "id" ]
+let checking_for_arcs = List.mem "arcs" keys_in_use_for_point
+let a = match checking_for_arcs with true -> "" | false -> "" *)

--- a/test/topojson/test.ml
+++ b/test/topojson/test.ml
@@ -101,7 +101,7 @@ let ezjsonm =
 let main () =
   let s = read_file "./test_cases/files/exemplar.json" in
   let json = Ezjsonm.value_from_string s in
-  let pp_ezjsonm ppf json = Fmt.pf ppf "%s" json in
+  let pp_ezjsonm ppf json = Fmt.pf ppf "%s"(Ezjsonm.value_to_string json) in
   let pp_foreign_member ppf (v : (string * Ezjsonm.value) list) =
     Fmt.pf ppf "%a" Fmt.(list (pair string pp_ezjsonm)) v
   in

--- a/test/topojson/test.ml
+++ b/test/topojson/test.ml
@@ -109,7 +109,7 @@ let pp_ezjsonm ppf json = Fmt.pf ppf "%s" (Ezjsonm.value_to_string json)
 let pp_foreign_member ppf (v : (string * Ezjsonm.value) list) =
   Fmt.pf ppf "%a" Fmt.(list (pair string pp_ezjsonm)) v
 
-let expected_foreign_members = [ ("arcs", `A [ `Float 0. ]) ]
+let expected_foreign_members = [ ("arcs", `A [ `Float 0.1 ]) ]
 let foreign_members = Alcotest.testable pp_foreign_member Stdlib.( = )
 
 let main () =
@@ -120,11 +120,13 @@ let main () =
   | Ok t, Ok (Topojson.Topology f) ->
       (* Here we check that the arcs defined in the file are the same as the ones
          we hardcoded above *)
-      Alcotest.(check foreign_members)
-        "same foreign_members" expected_foreign_members f.foreign_members;
       Alcotest.(check (array (array position))) "same arcs" f.arcs expected_arcs;
       (* Then we check that converting the Topojson OCaml value to JSON and then back
          again produces the same Topojson OCaml value. *)
+      Alcotest.(check foreign_members)
+        "same foreign_members" expected_foreign_members
+        (get_foreign_members_in_point f);
+
       let output_json = Topojson.to_json t in
       Alcotest.(check ezjsonm) "same ezjsonm" json output_json;
       Alcotest.(check (result topojson msg))

--- a/test/topojson/test.ml
+++ b/test/topojson/test.ml
@@ -101,7 +101,7 @@ let ezjsonm =
 let main () =
   let s = read_file "./test_cases/files/exemplar.json" in
   let json = Ezjsonm.value_from_string s in
-  let pp_ezjsonm ppf json = Fmt.pf ppf "%s"(Ezjsonm.value_to_string json) in
+  let pp_ezjsonm ppf json = Fmt.pf ppf "%s" (Ezjsonm.value_to_string json) in
   let pp_foreign_member ppf (v : (string * Ezjsonm.value) list) =
     Fmt.pf ppf "%a" Fmt.(list (pair string pp_ezjsonm)) v
   in

--- a/test/topojson/test.ml
+++ b/test/topojson/test.ml
@@ -55,24 +55,12 @@ let expected_arcs =
       |];
     |]
 
-let expected_foreign_members =
-  let open Topojson in
-  Geometry.foreign_members
-
 let pp_position ppf t =
   let open Topojson.Geometry in
   let lat = Position.lat t in
   let lng = Position.lng t in
   Fmt.pf ppf "[%f, %f]" lat lng
 
-let get_foreign_members_in_point (f : Topojson.Topology.t) =
-  let open Topojson in
-  let objs = List.hd f.objects |> snd in
-  match Geometry.geometry objs with
-  | Geometry.Collection (point :: _) -> Geometry.foreign_members point
-  | _ -> assert false
-
-let s = read_file "./test_cases/files/exemplar.json"
 let position = Alcotest.testable pp_position Stdlib.( = )
 let msg = Alcotest.testable (fun ppf (`Msg m) -> Fmt.pf ppf "%s" m) Stdlib.( = )
 
@@ -109,28 +97,32 @@ let ezjsonm =
     (fun ppf t -> Fmt.pf ppf "%s" (Ezjsonm.value_to_string t))
     ezjsonm_equal
 
-(* type pp_set_formatter_out_functions = {
-     foreign_member : Topojson.Geometry.foreign_members -> unit;
+let get_foreign_members_in_point (f : Topojson.Topology.t) =
+  let open Topojson in
+  let objs = List.hd f.objects |> snd in
+  match Geometry.geometry objs with
+  | Geometry.Collection (point :: _) -> Geometry.foreign_members point
+  | _ -> assert false
 
-   } *)
+let pp_ezjsonm ppf json = Fmt.pf ppf "%s" (Ezjsonm.value_to_string json)
+
+let pp_foreign_member ppf (v : (string * Ezjsonm.value) list) =
+  Fmt.pf ppf "%a" Fmt.(list (pair string pp_ezjsonm)) v
+
+let expected_foreign_members = [ ("arcs", `A [ `Float 0. ]) ]
+let foreign_members = Alcotest.testable pp_foreign_member Stdlib.( = )
+
 let main () =
   let s = read_file "./test_cases/files/exemplar.json" in
   let json = Ezjsonm.value_from_string s in
-
-  let pp_ezjsonm ppf json = Fmt.pf ppf "%s" (Ezjsonm.value_to_string json) in
-  let pp_foreign_member ppf (v : (string * get_foreign_members_in_point) list) =
-    Fmt.pf ppf "%a" Fmt.(list (pair string pp_ezjsonm)) v
-  in
-  let foreign_members = Alcotest.testable pp_foreign_member Stdlib.( = ) in
-
   let topojson_obj = Topojson.of_json json in
   match (topojson_obj, Result.map Topojson.topojson topojson_obj) with
   | Ok t, Ok (Topojson.Topology f) ->
       (* Here we check that the arcs defined in the file are the same as the ones
          we hardcoded above *)
-      Alcotest.(check (array (array position))) "same arcs" f.arcs expected_arcs;
       Alcotest.(check foreign_members)
-        d "same foreign_member" expected_foreign_members f.foreign_members;
+        "same foreign_members" expected_foreign_members f.foreign_members;
+      Alcotest.(check (array (array position))) "same arcs" f.arcs expected_arcs;
       (* Then we check that converting the Topojson OCaml value to JSON and then back
          again produces the same Topojson OCaml value. *)
       let output_json = Topojson.to_json t in

--- a/test/topojson/test.ml
+++ b/test/topojson/test.ml
@@ -61,10 +61,7 @@ let pp_position ppf t =
   let lng = Position.lng t in
   Fmt.pf ppf "[%f, %f]" lat lng
 
-let pp_foreign_member ppf (v : (string * Ezjsonm.value) list) =
-  Fmt.pf ppf "%a" Fmt.(list (pair string pp_ezjsonm)) v
-
-let foreign_members = Alcotest.testable pp_foreign_member Stdlib.( = )
+let s = read_file "./test_cases/files/exemplar.json"
 let position = Alcotest.testable pp_position Stdlib.( = )
 let msg = Alcotest.testable (fun ppf (`Msg m) -> Fmt.pf ppf "%s" m) Stdlib.( = )
 
@@ -104,6 +101,12 @@ let ezjsonm =
 let main () =
   let s = read_file "./test_cases/files/exemplar.json" in
   let json = Ezjsonm.value_from_string s in
+  let pp_ezjsonm ppf json = Fmt.pf ppf "%s" json in
+  let pp_foreign_member ppf (v : (string * Ezjsonm.value) list) =
+    Fmt.pf ppf "%a" Fmt.(list (pair string pp_ezjsonm)) v
+  in
+
+  let foreign_members = Alcotest.testable pp_foreign_member Stdlib.( = ) in
   let expected_foreign_members = [ ("arcs", json) ] in
   let topojson_obj = Topojson.of_json json in
   match (topojson_obj, Result.map Topojson.topojson topojson_obj) with
@@ -124,8 +127,4 @@ let main () =
   | Error (`Msg m), _ -> failwith m
   | _, Error (`Msg m) -> failwith m
 
-(* let point = Topojson.Geometry.Point.position *)
 let () = Alcotest.run "topojson" [ ("parsing", [ ("simple", `Quick, main) ]) ]
-(* let keys_in_use_for_point = [ "id" ]
-   let checking_for_arcs = List.mem "arcs" keys_in_use_for_point
-   let a = match checking_for_arcs with true -> "" | false -> "" *)

--- a/test/topojson/test.ml
+++ b/test/topojson/test.ml
@@ -61,8 +61,8 @@ let pp_position ppf t =
   let lng = Position.lng t in
   Fmt.pf ppf "[%f, %f]" lat lng
 
-  let pp_foreign_member ppf (v : (string * Ezjsonm.value) list) =
-    Fmt.pf ppf "%a" Fmt.(list (pair string pp_ezjsonm)) v
+let pp_foreign_member ppf (v : (string * Ezjsonm.value) list) =
+  Fmt.pf ppf "%a" Fmt.(list (pair string pp_ezjsonm)) v
 
 let foreign_members = Alcotest.testable pp_foreign_member Stdlib.( = )
 let position = Alcotest.testable pp_position Stdlib.( = )
@@ -96,7 +96,6 @@ and remove acc k = function
   | (k', _) :: rest when k = k' -> List.rev acc @ rest
   | x :: rest -> remove (x :: acc) k rest
 
-
 let ezjsonm =
   Alcotest.testable
     (fun ppf t -> Fmt.pf ppf "%s" (Ezjsonm.value_to_string t))
@@ -105,14 +104,14 @@ let ezjsonm =
 let main () =
   let s = read_file "./test_cases/files/exemplar.json" in
   let json = Ezjsonm.value_from_string s in
-  let expected_foreign_members = [("arcs", json)] in
+  let expected_foreign_members = [ ("arcs", json) ] in
   let topojson_obj = Topojson.of_json json in
   match (topojson_obj, Result.map Topojson.topojson topojson_obj) with
   | Ok t, Ok (Topojson.Topology f) ->
       (* Here we check that the arcs defined in the file are the same as the ones
          we hardcoded above *)
       Alcotest.(check (array (array position))) "same arcs" f.arcs expected_arcs;
-      Alcotest.(check  ( foreign_members))
+      Alcotest.(check foreign_members)
         "same foreign_member" expected_foreign_members f.foreign_members;
       (* Then we check that converting the Topojson OCaml value to JSON and then back
          again produces the same Topojson OCaml value. *)
@@ -128,5 +127,5 @@ let main () =
 (* let point = Topojson.Geometry.Point.position *)
 let () = Alcotest.run "topojson" [ ("parsing", [ ("simple", `Quick, main) ]) ]
 (* let keys_in_use_for_point = [ "id" ]
-let checking_for_arcs = List.mem "arcs" keys_in_use_for_point
-let a = match checking_for_arcs with true -> "" | false -> "" *)
+   let checking_for_arcs = List.mem "arcs" keys_in_use_for_point
+   let a = match checking_for_arcs with true -> "" | false -> "" *)

--- a/test/topojson/test_cases/files/exemplar.json
+++ b/test/topojson/test_cases/files/exemplar.json
@@ -9,7 +9,8 @@
           "properties": {
             "prop0": "value0"
           },
-          "coordinates": [102, 0.5]
+          "coordinates": [102, 0.5],
+          "arcs": [0]
         },
         {
           "type": "LineString",

--- a/test/topojson/test_cases/files/exemplar.json
+++ b/test/topojson/test_cases/files/exemplar.json
@@ -10,7 +10,7 @@
             "prop0": "value0"
           },
           "coordinates": [102, 0.5],
-          "arcs": [0]
+          "arcs": [0.1]
         },
         {
           "type": "LineString",


### PR DESCRIPTION
I created a new `keys_in_use_for_point` which doesn't contain `arcs` and applied the resultant `foreign_members_of_json_for_point` to `Point` and `MultiPoint` and then pushed the changes to `foreign_member` branch, hence the reason I'm opening a new PR on the same issue