### PR TITLE
testing parsing for exemplar.json

### DIFF
--- a/test/topojson/test_cases/files/exemplar.json
+++ b/test/topojson/test_cases/files/exemplar.json
@@ -28,6 +28,16 @@
             }
           },
           "arcs": [[-2]]
+        },
+        {
+          "type":"multipolygon",
+          "properties": {
+            "prop0": "value0",
+            "prop1": {
+              "this":"that"
+            }
+          },
+          "arcs":[[-1]]
         }
       ]
     }


### PR DESCRIPTION
issue #17: test that the `exemplar.json` GeomentryCollection is parsed correctly.

Mentor @patricoferris  I tried testing one of the Geometry objects `multipolygon` to see if it's parsed and has coordinates, but unfortunately after running a test on it using `dune runtest` it showed failed and I wonder what could be wrong.

Although, I'm still having a little misunderstanding on how to go about this. I would appreciate some help or pointers on how to resolve this issue.