### PR TITLE
Expose JSON conversion functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ setup.log
 
 # Local OPAM switch
 _opam/
+
+
+.vscode

--- a/src/topojson/topojson.ml
+++ b/src/topojson/topojson.ml
@@ -277,7 +277,7 @@ module Make (J : Intf.Json) = struct
 
     let id_of_json json = J.find json [ "id" ]
 
-    let rec base_of_json json =
+    let rec of_json json =
       let fm = foreign_members_of_json json in
       let properties = properties_of_json json in
       let id = id_of_json json in
@@ -341,7 +341,7 @@ module Make (J : Intf.Json) = struct
           | Ok "GeometryCollection" -> (
               match J.find json [ "geometries" ] with
               | Some list ->
-                  let geo = J.to_list (decode_or_err base_of_json) list in
+                  let geo = J.to_list (decode_or_err of_json) list in
                   Result.map
                     (fun g ->
                       {
@@ -421,13 +421,13 @@ module Make (J : Intf.Json) = struct
           List.filter (fun (k, _v) -> not (List.mem k keys_in_use)) assoc
       | Error _ -> []
 
-    let base_of_json json =
+    let of_json json =
       match (J.find json [ "objects" ], J.find json [ "arcs" ]) with
       | Some objects, Some arcs ->
           let* objects = J.to_obj objects in
           let geometries =
             List.map
-              (fun (k, v) -> (k, decode_or_err Geometry.base_of_json v))
+              (fun (k, v) -> (k, decode_or_err Geometry.of_json v))
               objects
           in
           let* arcs =
@@ -470,7 +470,7 @@ module Make (J : Intf.Json) = struct
     | Some typ, bbx -> (
         match J.to_string typ with
         | Ok "Topology" -> (
-            match Topology.base_of_json json with
+            match Topology.of_json json with
             | Ok v ->
                 Ok (topojson_to_t (Topology v) @@ Option.bind bbx json_to_bbox)
             | Error e -> Error e)

--- a/src/topojson/topojson_intf.ml
+++ b/src/topojson/topojson_intf.ml
@@ -55,6 +55,12 @@ end
 module type Json_conv = sig
   type t
   type json
+
+  val to_json : t -> json
+  (** Convert a [t] to a JSON representation. *)
+
+  val of_json : json -> (t, [ `Msg of string ]) result
+  (** Attempt to deserialise a [t] from JSON.*)
 end
 
 (** {2 topojson Geometry Objects}
@@ -198,7 +204,8 @@ module type Geometry = sig
 
   (** Creates a new Geometry object. *)
 
-  include Json_conv with type t := t and type json := json
+  val to_json : ?bbox:float array -> t -> json
+  val of_json : json -> (t, [ `Msg of string ]) result
 end
 
 module type S = sig
@@ -214,7 +221,8 @@ module type S = sig
       foreign_members : (string * json) list;
     }
 
-    include Json_conv with type t := t and type json := json
+    val to_json : ?bbox:float array -> t -> json
+    val of_json : json -> (t, [ `Msg of string ]) result
   end
 
   type topojson = Topology of Topology.t | Geometry of Geometry.t


### PR DESCRIPTION
This exposes some JSON conversion functions. I'm not overly happy with the interface at the moment. We move common fields up the stack into higher objects if they are shared e.g. bounding box -- but this leaks into our JSON conv functions which isn't great. I think we should refactor this, but for now this should unblock #28 