### PR TITLE
Add constructors and rename Arcs to Arc_index

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -23,8 +23,7 @@
    (bechamel-notty (and (>= 0.1.0) :with-test))
    (mdx (and (>= 1.10.0) :with-test))
    (alcotest :with-test)
-   (ezjsonm  :with-test)
-   (geojson  :with-test)))
+   (ezjsonm  :with-test)))
 
 (package
  (name topojsonm)

--- a/src/topojson/dune
+++ b/src/topojson/dune
@@ -1,4 +1,4 @@
 (library
  (public_name topojson)
  (name topojson)
- (libraries geojson))
+ (libraries))

--- a/src/topojson/topojson.ml
+++ b/src/topojson/topojson.ml
@@ -131,7 +131,7 @@ module Make (J : Intf.Json) = struct
           @ foreign_members)
     end
 
-    module Arcs = struct
+    module Arc_index = struct
       type t = int array
 
       let v t = t
@@ -164,7 +164,7 @@ module Make (J : Intf.Json) = struct
     end
 
     module LineString = struct
-      type t = Arcs.t
+      type t = Arc_index.t
 
       let typ = "LineString"
       let v arc = arc
@@ -173,7 +173,7 @@ module Make (J : Intf.Json) = struct
 
       let to_json ?bbox ?(properties = `None) ?(foreign_members = []) arc =
         J.obj
-          ([ ("type", J.string typ); ("arcs", Arcs.to_json arc) ]
+          ([ ("type", J.string typ); ("arcs", Arc_index.to_json arc) ]
           @ properties_or_null properties
           @ bbox_to_json_or_empty bbox
           @ foreign_members)
@@ -193,7 +193,7 @@ module Make (J : Intf.Json) = struct
 
       let to_json ?bbox ?(properties = `None) ?(foreign_members = []) arcs =
         J.obj
-          ([ ("type", J.string typ); ("arcs", J.array Arcs.to_json arcs) ]
+          ([ ("type", J.string typ); ("arcs", J.array Arc_index.to_json arcs) ]
           @ properties_or_null properties
           @ bbox_to_json_or_empty bbox
           @ foreign_members)
@@ -268,6 +268,13 @@ module Make (J : Intf.Json) = struct
 
     let geometry t = t.geometry
     let properties t = t.properties
+    let point t = Point (Point.v t)
+    let multipoint t = MultiPoint (MultiPoint.v t)
+    let linestring t = LineString (LineString.v t)
+    let multilinestring t = MultiLineString (MultiLineString.v t)
+    let polygon p = Polygon (Polygon.v p)
+    let multipolygon mp = MultiPolygon (MultiPolygon.v mp)
+    let collection cs = Collection cs
 
     let get_point = function
       | Point p -> Ok p

--- a/src/topojson/topojson_intf.ml
+++ b/src/topojson/topojson_intf.ml
@@ -101,12 +101,12 @@ module type Geometry = sig
     (** Create a point from a position. *)
   end
 
-  module Arcs : sig
+  module Arc_index : sig
     type t
-    (** Arcs is an array of arc indexes *)
+    (** An array of indexes into the arcs field. *)
 
     val v : int array -> t
-    (** Converts an array to arc *)
+    (** A constructors for building an arc-index from an integer array. *)
   end
 
   module MultiPoint : sig
@@ -124,8 +124,8 @@ module type Geometry = sig
     type t
     (** A line string is two or more points *)
 
-    val v : Arcs.t -> t
-    (** Creates a line string from arc indexes *)
+    val v : Arc_index.t -> t
+    (** Creates a line string from an arc index. *)
   end
 
   module MultiLineString : sig
@@ -181,6 +181,18 @@ module type Geometry = sig
       ([`None]), could be specifically a null value ([`Null]) or an object. *)
 
   and t
+
+  (** {2 Constructors} *)
+
+  val point : Position.t -> geometry
+  val multipoint : Point.t array -> geometry
+  val linestring : Arc_index.t -> geometry
+  val multilinestring : LineString.t array -> geometry
+  val polygon : LineString.t array -> geometry
+  val multipolygon : Polygon.t array -> geometry
+  val collection : t list -> geometry
+
+  (** {2 Conversion functions}*)
 
   val get_point : geometry -> (Point.t, [> `Msg of string ]) result
   val get_point_exn : geometry -> Point.t

--- a/test/topojson/test.ml
+++ b/test/topojson/test.ml
@@ -135,19 +135,17 @@ let geometries () =
   | Collection [ point; _linestring; _polygon ] ->
       let geo_point = Geometry.geometry point in
       let expected_point =
-        Geometry.(Point (Point.v @@ Position.v ~lng:102. ~lat:0.5 ()))
+        Geometry.(point (Position.v ~lng:102. ~lat:0.5 ()))
       in
       Alcotest.(check inner_geometry) "same point" geo_point expected_point;
       let geo_linestring = Geometry.geometry _linestring in
-      let expected_linestring =
-        Geometry.(LineString (LineString.v @@ Arcs.v [| 0 |]))
-      in
+      let expected_linestring = Geometry.(linestring @@ Arc_index.v [| 0 |]) in
       Alcotest.(check inner_geometry)
         "same point" geo_linestring expected_linestring;
 
       let geo_polygon = Geometry.geometry _polygon in
       let expected_polygon =
-        Geometry.(Polygon (Polygon.v [| LineString.v @@ Arcs.v [| -2 |] |]))
+        Geometry.(polygon [| LineString.v @@ Arc_index.v [| -2 |] |])
       in
       Alcotest.(check inner_geometry) "same point" geo_polygon expected_polygon
   | _ -> Alcotest.fail "Expected a collection of geometries"

--- a/topojson.opam
+++ b/topojson.opam
@@ -16,7 +16,6 @@ depends: [
   "mdx" {>= "1.10.0" & with-test}
   "alcotest" {with-test}
   "ezjsonm" {with-test}
-  "geojson" {with-test}
   "odoc" {with-doc}
 ]
 build: [
@@ -36,6 +35,3 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/patricoferris/ocaml-topojson.git"
-pin-depends: [
-  [ "geojson.dev" "git+https://github.com/geocaml/ocaml-geojson#fd422ecee7fc606e5f24a21bb27a9b5825d87efd" ]
-]

--- a/topojson.opam.template
+++ b/topojson.opam.template
@@ -1,3 +1,0 @@
-pin-depends: [
-  [ "geojson.dev" "git+https://github.com/geocaml/ocaml-geojson#fd422ecee7fc606e5f24a21bb27a9b5825d87efd" ]
-]


### PR DESCRIPTION
This PR adds some helper constructors to construct geometry objects and renames Arcs to Arc_index to distinguish between that and the arcs in the topojson object.