### PR TITLE
Example usage of foreign_members

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,5 @@ Given the Topojson Object above, we can extract the foreign members by using the
 
 ```ocaml
 # Topojson.Geometry.foreign_members topojson;;
+- : (string * Topojson.json) list = [("foreign", `String "8")]
 ```

--- a/README.md
+++ b/README.md
@@ -118,3 +118,11 @@ val t : Topojson.t = <abstr>
 - : string =
 "{\"type\":\"Topology\",\"objects\":{\"example\":{\"type\":\"LineString\",\"arcs\":[0],\"foreign\":\"8\"}},\"arcs\":[[[0,0]]]}"
 ```
+
+#### Example usage of foreign_members
+
+Given the Topojson Object above, we can extract the foreign members by using the foreign_member function in the Topojson.Geometry module.
+
+```ocaml
+let foreign_member_usage = Topojson.Geometry.foreign_members topojson
+```

--- a/README.md
+++ b/README.md
@@ -124,5 +124,5 @@ val t : Topojson.t = <abstr>
 Given the Topojson Object above, we can extract the foreign members by using the foreign_member function in the Topojson.Geometry module.
 
 ```ocaml
-let foreign_member_usage = Topojson.Geometry.foreign_members topojson
+# Topojson.Geometry.foreign_members topojson;;
 ```


### PR DESCRIPTION
Using `foreign_members` function to read some key-value pairs that are not a part of the specification.